### PR TITLE
Jekyll overhaul, part two

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,9 @@ GEM
     eventmachine (1.2.7)
     ffi (1.15.5)
     forwardable-extended (2.6.0)
+    google-protobuf (3.23.3)
     google-protobuf (3.23.3-arm64-darwin)
+    google-protobuf (3.23.3-x86_64-linux)
     http_parser.rb (0.8.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -47,13 +49,19 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (5.0.1)
+    rake (13.0.6)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.5)
     rouge (4.1.2)
     safe_yaml (1.0.5)
+    sass-embedded (1.63.4)
+      google-protobuf (~> 3.23)
+      rake (>= 13.0.0)
     sass-embedded (1.63.4-arm64-darwin)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.63.4-x86_64-linux-gnu)
       google-protobuf (~> 3.23)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -62,6 +70,8 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  ruby
+  x86_64-linux
 
 DEPENDENCIES
   jekyll (~> 4.3.2)

--- a/README.md
+++ b/README.md
@@ -3,48 +3,46 @@
 - [Speck\&Tech](#specktech)
   - [System Preparation](#system-preparation)
   - [Local Installation](#local-installation)
-  - [Usage](#usage)
-    - [Development mode](#development-mode)
-    - [Jekyll](#jekyll)
+  - [Jekyll Development Mode](#jekyll-development-mode)
   - [Deploy](#deploy)
   - [Management](#management)
     - [Events on the homepage hero](#events-on-the-homepage-hero)
       - [Use the "event" type](#use-the-event-type)
       - [Use the "loading" type](#use-the-loading-type)
 
-
 ## System Preparation
 
-To use this starter project, you'll need the following things installed on your machine.
+You'll need [Ruby](https://www.ruby-lang.org/en/documentation/installation/) and the [Bundler](https://bundler.io/) gem installed on your machine:
 
-1. [Ruby](https://www.ruby-lang.org/en/)
-2. [NodeJS](http://nodejs.org) - use the installer.
-3. [Jekyll](http://jekyllrb.com/) - `$ gem install jekyll`
+```shell
+brew install ruby   # or use asdf or rbenv
+gem install bundler
+```
 
 ## Local Installation
 
 1. Clone this repo, or download it into a directory of your choice.
-2. Inside the directory, run `npm install`
+2. Inside the directory, run `bundle install`. It will fetch [Jekyll](http://jekyllrb.com) and its dependencies.
 
-## Usage
+Compatibility issues with your platform? Fear not! Just run `bundle lock --add-platform <platform>`.
 
-### Development mode
+## Jekyll Development Mode
 
-This will give you file watching, browser synchronisation, auto-rebuild, CSS injecting etc.
+To get the server running:
 
 ```shell
-$ npm run gulp
+bundle exec jekyll serve
+# in alternative
+jekyll serve
 ```
 
-### Jekyll
-
-As this is just a Jekyll project, you can use any of the commands listed in their [docs](http://jekyllrb.com/docs/usage/)
+It will take care of livereloading and Sass compiling. If you need more info, please see the [Jekyll docs](http://jekyllrb.com/docs/usage/).
 
 ## Deploy
 
 When you push to `master`, Github Pages will take care of building the website and deploying it at [http://speckand.tech](https://www.ruby-lang.org/en/).
 
----
+<br><hr><br>
 
 ## Management
 

--- a/_config.yml
+++ b/_config.yml
@@ -3,8 +3,7 @@ title: Speck&Tech
 
 description: ""
 
-baseurl: / # the subpath of the site
-url: / # the base hostname & protocol for the site
+url: https://speckand.tech
 permalink: "/:year/:month/:title/"
 
 port: 4268


### PR DESCRIPTION
Just three quick updates:

- Revert `url` in config and fix the broken assets
- Add support for the standard linux platform in the `Gemfile.lock`
- Update the Readme: installation and development tutorials